### PR TITLE
updating to use more readable f strings vs .format

### DIFF
--- a/scripts/connect_to_mongo.py
+++ b/scripts/connect_to_mongo.py
@@ -41,7 +41,7 @@ def MongoDB_Client(destination: str, env:str, dbName = None):
     credentials['PWD'] = urllib.parse.quote(credentials['PWD'])
     credentials['URL'] = urllib.parse.quote(credentials['mydbcluster'])
 
-    client = pymongo.MongoClient("mongodb://{}:{}@{}.us-east-1.docdb.amazonaws.com:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false".format(credentials['UID'], credentials['PWD'],credentials['mydbcluster'])
+    client = pymongo.MongoClient(f"mongodb://{credentials['UID']}:{credentials['PWD']}@{credentials['mydbcluster']}.us-east-1.docdb.amazonaws.com:27017/?ssl=true&ssl_ca_certs=rds-combined-ca-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
     )
     if dbName is None:
         return client

--- a/scripts/connect_to_rds.py
+++ b/scripts/connect_to_rds.py
@@ -29,12 +29,12 @@ def create_postgres_engine(destination: str, target_db: str, env: str):
     credentials = get_connection_strings(destination)
     env = env.upper()
 
-    uid =urllib.parse.quote("{}".format(credentials[env]['UID']))
-    pwd = urllib.parse.quote("{}".format(credentials[env]['PWD']))
-    host=urllib.parse.quote("{}".format(credentials[env]['HOST']))
-    port=urllib.parse.quote("{}".format(credentials[env]['PORT']))
+    uid =urllib.parse.quote(f"{credentials[env]['UID']}")
+    pwd = urllib.parse.quote(f"{credentials[env]['PWD']}")
+    host=urllib.parse.quote(f"{credentials[env]['HOST']}")
+    port=urllib.parse.quote(f"{credentials[env]['PORT']}")
     
-    connection_string = "postgresql://{}:{}@{}:{}/{}".format(uid, pwd, host, port, target_db)
+    connection_string = f"postgresql://{uid}:{pwd}@{host}:{port}/{target_db}"
 
     engine = sqlalchemy.create_engine(connection_string)
 

--- a/scripts/download_analysis_data_samples.py
+++ b/scripts/download_analysis_data_samples.py
@@ -27,7 +27,7 @@ SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'analysis_
 tables_to_download = [r for (r,) in engine.execute(get_tables_query).fetchall()]
 
 for table in tables_to_download:
-    df = pd.read_sql('select * from analysis_data.{} limit 1000'.format(table), engine, coerce_float=False)
-    download_path = os.path.join(data_folder, 'analysis_data_'+table+'.csv')
+    df = pd.read_sql(f'select * from analysis_data.{table} limit 1000', engine, coerce_float=False)
+    download_path = os.path.join(data_folder, f'analysis_data_{table}.csv')
     df.to_csv(download_path, index=False)
-    print('downloaded table ', table,' with ',len(df),' records')
+    print(f'downloaded table {table} with {len(df)} records')

--- a/scripts/download_viz_csvs.py
+++ b/scripts/download_viz_csvs.py
@@ -27,7 +27,7 @@ SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'viz'
 tables_to_download = [r for (r,) in engine.execute(get_tables_query).fetchall()]
 
 for table in tables_to_download:
-    df = pd.read_sql('select * from viz.{}'.format(table), engine, coerce_float=False)
+    df = pd.read_sql(f'select * from viz.{table}', engine, coerce_float=False)
     download_path = os.path.join(data_folder, table+'.csv')
     df.to_csv(download_path, index=False)
     print('downloaded table ', table,' with ',len(df),' records')

--- a/scripts/generate_census_block_level_aggregate.py
+++ b/scripts/generate_census_block_level_aggregate.py
@@ -81,19 +81,19 @@ for table in datasets_scripts.keys():
     else:
         schema='tmp'
 
-    create_schema_query="""
-        CREATE SCHEMA IF NOT EXISTS {0};
-        GRANT ALL PRIVILEGES ON SCHEMA {0} TO PUBLIC;
-    """.format(schema)
+    create_schema_query=f"""
+        CREATE SCHEMA IF NOT EXISTS {schema};
+        GRANT ALL PRIVILEGES ON SCHEMA {schema} TO PUBLIC;
+    """
 
-    create_table_query ="""
-    DROP TABLE IF EXISTS {0}.{1};
-    CREATE TABLE {0}.{1} 
+    create_table_query =f"""
+    DROP TABLE IF EXISTS {schema}.{table};
+    CREATE TABLE {schema}.{table} 
     AS (
-        {2}
+        {datasets_scripts[table]}
     );
-    GRANT ALL PRIVILEGES ON {0}.{1} TO PUBLIC;
-    """.format(schema, table, datasets_scripts[table])
+    GRANT ALL PRIVILEGES ON {schema}.{table} TO PUBLIC;
+    """
 
     engine.execute(create_schema_query)
     engine.execute(create_table_query)

--- a/scripts/generate_moving_violations.py
+++ b/scripts/generate_moving_violations.py
@@ -61,12 +61,12 @@ for record in records:
         geo_loc_instance = GeoLoc(GOOGLE_API_KEY)
         lat_long = geo_loc_instance.GetGeoLoc(address_url_enc)
         # insert into the table
-        insert_record_query = "INSERT INTO source_data.mv_geocodes VALUES (\'{0}\',{1},{2})".format(address, lat_long["lat"], lat_long["lng"])
+        insert_record_query = f"INSERT INTO source_data.mv_geocodes VALUES (\'{address}\',{lat_long["lat"]},{lat_long["lng"]})"
         engine.execute(insert_record_query)
     except Exception as error:
         print("could not find location for address ", address)
         # insert into the missing values table
-        insert_missing_record_query = "INSERT INTO source_data.mv_location_no_geocodes VALUES (\'{0}\')".format(address)
+        insert_missing_record_query = f"INSERT INTO source_data.mv_location_no_geocodes VALUES (\'{address}\')"
         try:
             engine.execute(insert_missing_record_query)
         except:

--- a/scripts/generate_pulsepoint.py
+++ b/scripts/generate_pulsepoint.py
@@ -76,14 +76,14 @@ AS (
     ) WITH DATA; 
 """
 
-final_query="""
-DROP TABLE IF EXISTS {0}.{1};
+final_query=f"""
+DROP TABLE IF EXISTS {target_schema}.{target_table};
 
-CREATE TABLE {0}.{1} AS 
+CREATE TABLE {target_schema}.{target_table} AS 
     SELECT * FROM tmp_pulsepoint_units_join;
 
-GRANT ALL PRIVILEGES ON {0}.{1} TO PUBLIC;
-""".format(target_schema, target_table)
+GRANT ALL PRIVILEGES ON {target_schema}.{target_table} TO PUBLIC;
+"""
 
 engine.execute(step1_query)
 engine.execute(step_2_query)

--- a/scripts/get_acs.py
+++ b/scripts/get_acs.py
@@ -35,7 +35,7 @@ for state_code, state_abbrev in states.items():
 
     census_params={"get":variables
                 ,"for":"tract:*"
-                ,"in":"state:{}".format(state_code)
+                ,"in":f"state:{state_code}"
                 ,"key":Census_API_Key
                 }
     response = requests.get(census_endpoint, params = census_params)
@@ -45,5 +45,5 @@ for state_code, state_abbrev in states.items():
         for line in response.text.split('\n'):
             output.write(line.replace("[","").replace("],","") + '\n')
     data = open(filename, 'rb')
-    s3.Bucket(bucket_name).put_object(Key='source-data/census/acs/acs2019_{}.csv'.format(state_abbrev), Body=data, Metadata =metadata)
+    s3.Bucket(bucket_name).put_object(Key=f'source-data/census/acs/acs2019_{state_abbrev}.csv', Body=data, Metadata =metadata)
 

--- a/scripts/get_address.py
+++ b/scripts/get_address.py
@@ -11,8 +11,7 @@ class GeoLoc:
         self.google_key = token
 
     def GetGeoLoc(self, test_address):
-        url = "https://maps.googleapis.com/maps/api/geocode/json?address={final_address}&key={GOOGLE_KEY}".format(
-            final_address=test_address, GOOGLE_KEY=self.google_key)
+        url = f"https://maps.googleapis.com/maps/api/geocode/json?address={test_address}&key={self.google_key}"
         # print(url)
 
         r = requests.get(url)

--- a/scripts/get_walkscore.py
+++ b/scripts/get_walkscore.py
@@ -79,7 +79,7 @@ for record in records:
         bikescore=content['bike']['score']
         transitscore=content['transit']['score']
         # insert into the table
-        insert_record_query = "INSERT INTO source_data.address_walkscores VALUES (\'{0}\',\'{1}\',{2},{3},{4},{5},{6},{7})".format(address, census_block, geography, lat, long, walkscore, bikescore, transitscore)
+        insert_record_query = f"INSERT INTO source_data.address_walkscores VALUES (\'{address}\',\'{census_block}\',{geography},{lat},{long},{walkscore},{bikescore},{transitscore})"
         engine.execute(insert_record_query)
     except Exception as error:
         print("could not find location for address ", address)

--- a/scripts/scrape_pulsepoint.py
+++ b/scripts/scrape_pulsepoint.py
@@ -19,7 +19,7 @@ dataset = 'pulsepoint'
 
 def main(agency:str):
 
-    url = "https://web.pulsepoint.org/DB/giba.php?agency_id={}".format(agency)
+    url = f"https://web.pulsepoint.org/DB/giba.php?agency_id={agency}"
 
     current_time = datetime.datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S+00:00")
 


### PR DESCRIPTION
I was reviewing this and trying to make sense of it, so I translated instances of .format() to f strings. 

If you are in python 3.6 (iirc) or greater, then f strings are typically more readable and easier to write. 

If there's a reason that this needs to be compatible with python < 3.6, feel free to close this :) 